### PR TITLE
[codex] add cross-agent project memory parity

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -10,6 +10,13 @@
   "repository": "https://github.com/freemty/labmate",
   "license": "MIT",
   "keywords": ["research", "experiment", "codex", "agents", "skills", "harness", "ai-research"],
+  "agents": [
+    "./agents/project-advisor.md",
+    "./agents/domain-expert.md",
+    "./agents/exp-manager.md",
+    "./agents/slides-maker.md",
+    "./agents/viz-frontend.md"
+  ],
   "skills": "./skills/",
   "hooks": "./hooks/hooks.json",
   "interface": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@
 - post-docs-remind hook: feat/fix/refactor commit 后提醒更新文档（2h 冷却）
 - pre-compact-archive hook: context 压缩前检测对话密度，提醒归档知识
 - post-skill-stale hook: 检测 5+ commits 后 project skill 滞后（4h 冷却）
+- Codex/Antigravity project-memory parity guard: 新增 `references/check_agent_parity.sh`，校验 `CLAUDE.md`/`AGENTS.md`、`.claude/skills/project-skill`/`.agents/skills/project-skill` 与 agent-memory 镜像
 
 ### 变更
 - /update-knowhow 变为 /update-docs 的轻量 alias
 - 分类判断完全由 agent 自主决定，移除 "If unclear, ask user once"
+- init-project/update-project-skill 会按目标 agent 生成或镜像 `.claude` 与 `.agents` 项目记忆，并在双入口项目中运行 parity guard
+- session-start hook 改为平台感知的 project-skill 路径选择，支持 `CLAUDE_PLUGIN_ROOT`、`CODEX_PLUGIN_ROOT` 与 `PLUGIN_ROOT`
+- 模板、README、教程和 active agents 更新为 Claude Code / Codex / Antigravity 兼容表述
 
 ## v0.8.0 (2026-04-15)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to LabMate
 
-Thanks for your interest in contributing! LabMate is a pure-Markdown Claude Code plugin — no build step, no dependencies.
+Thanks for your interest in contributing! LabMate is a pure-Markdown research harness for AI coding agents — no build step, no dependencies.
 
 ## Quick start
 
@@ -44,7 +44,7 @@ Types: feat, fix, refactor, docs, test, chore
 
 - Pure Markdown — no runtime dependencies
 - Files under 400 lines
-- Test changes by installing the plugin locally and running the relevant skill/agent
+- Test changes by installing the plugin locally and running the relevant skill/agent. For project-memory changes, verify both Claude Code (`CLAUDE.md` / `.claude/`) and Codex or Antigravity (`AGENTS.md` / `.agents/`) behavior when both surfaces are present.
 
 ## Finding work
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Your AI labmate for the full research lifecycle — from reading papers to runni
 
 ## The problem
 
-You start a research project with Claude. Three hours later you're debugging a CUDA kernel and have completely forgotten what hypothesis you were testing.
+You start a research project with an AI coding agent. Three hours later you're debugging a CUDA kernel and have completely forgotten what hypothesis you were testing.
 
 Your agent is no better — doesn't know what you tried last week, can't read your reference papers, and treats every session like day one.
 
@@ -28,7 +28,7 @@ Then run `/init-project` in your existing research project. LabMate auto-detects
 
 ### Tutorial
 
-New to Claude Code for research? Start here: **[CC Research Playbook](https://freemty.github.io/cc-research-playbook.html)** — covers context engineering, skills, hooks, sub-agents, and how LabMate ties it all together.
+New to agentic coding for research? Start here: **[CC Research Playbook](https://freemty.github.io/cc-research-playbook.html)** — covers context engineering, skills, hooks, sub-agents, and how LabMate ties it all together. LabMate keeps project memory portable across Claude Code (`CLAUDE.md` / `.claude/`) and Codex or Antigravity (`AGENTS.md` / `.agents/`).
 
 ### Recommended companions
 
@@ -139,9 +139,11 @@ mkdir -p .claude/agents
 # Your local .claude/agents/domain-expert.md overrides the plugin version
 ```
 
+For Codex or Antigravity project memory, use `.agents/skills/project-skill/` and keep it mirrored with `.claude/skills/project-skill/` when both platforms are active.
+
 ## Under the hood
 
-5 specialized agents, 12 skills, 8 hooks working together. See [CLAUDE.md](CLAUDE.md) for the technical architecture.
+5 specialized agents, 12 skills, 8 hooks working together. See [CLAUDE.md](CLAUDE.md) / `AGENTS.md` for the technical architecture in initialized projects.
 
 ## Acknowledgments
 
@@ -153,7 +155,7 @@ mkdir -p .claude/agents
 
 ```bibtex
 @software{labmate2026,
-  title   = {LabMate: Research Harness for Claude Code},
+  title   = {LabMate: Research Harness for AI Coding Agents},
   author  = {freemty},
   year    = {2026},
   version = {0.9.1},

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -10,7 +10,7 @@
 
 ## 问题
 
-你用 Claude 开始一个研究项目。三小时后你在 debug 一个 CUDA kernel，完全忘了自己在验证什么假设。
+你用 AI coding agent 开始一个研究项目。三小时后你在 debug 一个 CUDA kernel，完全忘了自己在验证什么假设。
 
 你的 agent 也好不到哪去——不知道你上周试过什么，看不了你的参考论文，每次开会话都像第一天上班。
 
@@ -27,7 +27,7 @@ LabMate 管两头。给 agent 装上实验记忆和论文知识。给你一套�
 
 ### 教程
 
-第一次用 Claude Code 做研究？从这里开始：**[CC Research Playbook](https://freemty.github.io/cc-research-playbook.html)** — 讲解 context engineering、skills、hooks、sub-agent，以及 LabMate 如何把这些串起来。
+第一次用 agentic coding 做研究？从这里开始：**[CC Research Playbook](https://freemty.github.io/cc-research-playbook.html)** — 讲解 context engineering、skills、hooks、sub-agent，以及 LabMate 如何把这些串起来。LabMate 会把项目记忆分流到 Claude Code 的 `CLAUDE.md` / `.claude/`，以及 Codex / Antigravity 的 `AGENTS.md` / `.agents/`。
 
 ### 推荐搭配
 
@@ -138,9 +138,11 @@ mkdir -p .claude/agents
 # 你的 .claude/agents/domain-expert.md 自动覆盖 plugin 版本
 ```
 
+如果同时使用 Claude Code 和 Codex / Antigravity，保持 `.claude/skills/project-skill/` 与 `.agents/skills/project-skill/` 镜像一致。
+
 ## 技术架构
 
-5 个专业 agent、9 个 skill、8 个 hook 协同工作。详见 [CLAUDE.md](CLAUDE.md)。
+5 个专业 agent、12 个 skill、8 个 hook 协同工作。初始化后的项目详见 `CLAUDE.md` / `AGENTS.md`。
 
 ## 致谢
 
@@ -152,7 +154,7 @@ mkdir -p .claude/agents
 
 ```bibtex
 @software{labmate2026,
-  title   = {LabMate: Research Harness for Claude Code},
+  title   = {LabMate: Research Harness for AI Coding Agents},
   author  = {freemty},
   year    = {2026},
   version = {0.5.0},

--- a/agents/domain-expert.md
+++ b/agents/domain-expert.md
@@ -279,7 +279,7 @@ You may write to:
 - `docs/papers/` — paper notes and landscape.md
 - Your memory directory — accumulated knowledge
 
-You do NOT write to: `exp/`, `.claude/`, `CLAUDE.md`, or any code files.
+You do NOT write to: `exp/`, `.claude/`, `.agents/`, `CLAUDE.md`, `AGENTS.md`, or any code files.
 
 ## Data Sources
 

--- a/agents/exp-manager.md
+++ b/agents/exp-manager.md
@@ -111,4 +111,4 @@ You may:
 - Run Bash commands (monitoring, retry, kill)
 - Update `.pipeline-state.json` (stage advancement)
 
-You do NOT modify: experiment code, config files, docs, or `.claude/` infrastructure.
+You do NOT modify: experiment code, config files, docs, `.claude/` infrastructure, or `.agents/` infrastructure.

--- a/agents/slides-maker.md
+++ b/agents/slides-maker.md
@@ -56,7 +56,7 @@ Content types: `slides` (default), `onboarding`, `demo-script`
 
    | Step | Read | Extract |
    |------|------|---------|
-   | 1 | `CLAUDE.md` | Project name, description, agent/skill/hook counts |
+   | 1 | `AGENTS.md` or `CLAUDE.md` | Project name, description, agent/skill/hook counts |
    | 2 | `agents/*.md` (via Glob) | Each agent: name, model, description |
    | 3 | `skills/*/SKILL.md` (via Glob) | Each skill: name, trigger |
    | 4 | `.pipeline-state.json` | Current stage, active experiment |

--- a/agents/viz-frontend.md
+++ b/agents/viz-frontend.md
@@ -123,7 +123,7 @@ Write ONLY to `viewer/` directory:
 - `viewer/static/index.html` — frontend
 - `viewer/static/` — any additional static assets
 
-Do NOT touch: `exp/`, `docs/`, `.claude/`, or any other directory.
+Do NOT touch: `exp/`, `docs/`, `.claude/`, `.agents/`, or any other directory.
 
 ## Quality Rules
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -8,7 +8,7 @@ This walks you through a complete research cycle with LabMate, from install to a
 claude plugin install freemty/labmate
 ```
 
-Open Claude Code in your project directory. You should see a LabMate prompt suggesting `/init-project` — that's the SessionStart hook confirming the plugin loaded.
+Open your agentic coding tool in the project directory. In Claude Code this creates `CLAUDE.md` and `.claude/skills/project-skill/`; in Codex or Antigravity it creates `AGENTS.md` and `.agents/skills/project-skill/`. You should see a LabMate prompt suggesting `/init-project` — that's the SessionStart hook confirming the plugin loaded.
 
 ## 1. Initialize your project
 
@@ -53,7 +53,7 @@ my-nlp-project/
 ├── viewer/
 │   └── app.py
 ├── slides/
-├── CLAUDE.md               # your research hub — principles, agents, workflow
+├── CLAUDE.md or AGENTS.md  # your research hub — principles, agents, workflow
 └── .pipeline-state.json    # tracks current experiment + stage
 ```
 
@@ -114,7 +114,7 @@ LabMate also updates `exp/exp01a/README.md` with findings and `exp/summary.md` w
 you: /update-project-skill
 ```
 
-This compresses your findings into `.claude/skills/project-skill/SKILL.md` — persistent memory that survives across sessions. Next time you open this project, your agent already knows what you tried and what worked.
+This compresses your findings into the project-local skill (`.agents/skills/project-skill/SKILL.md` for Codex/Antigravity or `.claude/skills/project-skill/SKILL.md` for Claude Code) — persistent memory that survives across sessions. Next time you open this project, your agent already knows what you tried and what worked.
 
 ## 6. Iterate
 
@@ -127,7 +127,7 @@ LabMate creates `exp/exp01b/` (variant of exp01). The cycle repeats.
 
 ## What happens across sessions
 
-When you come back tomorrow and open Claude Code:
+When you come back tomorrow and open Claude Code, Codex, or Antigravity:
 
 1. SessionStart hook reads `.pipeline-state.json` and tells your agent where you left off
 2. Your agent checks `exp/summary.md` for experiment history
@@ -138,7 +138,7 @@ No more "what were we doing again?"
 
 ## Tips
 
-- **Read your CLAUDE.md** — it's the single source of truth for your research workflow. The Research Principles section is worth internalizing.
+- **Read your project instruction file** — `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex/Antigravity. It is the source of truth for workflow routing. If both exist, keep them behaviorally aligned.
 - **Use `@domain-expert`** to read papers before designing experiments. Ask it to check `docs/papers/landscape.md` for related work.
 - **Commit after each experiment** — LabMate's workflow depends on git history to track what's been tried.
 - **Don't skip `/update-project-skill`** — it's what gives your agent long-term memory. Run it after every significant finding.
@@ -151,4 +151,4 @@ If you work in a specific domain, override the `@domain-expert` agent:
 mkdir -p .claude/agents
 ```
 
-Create `.claude/agents/domain-expert.md` with domain-specific knowledge (what baselines matter in your field, what metrics to use, which conferences to cite). Your local version takes priority over the plugin default.
+Create `.claude/agents/domain-expert.md` with domain-specific knowledge (what baselines matter in your field, what metrics to use, which conferences to cite). Your local version takes priority over the plugin default. For project memory, mirror `.claude/skills/project-skill/` and `.agents/skills/project-skill/` when both Claude Code and Codex/Antigravity are active.

--- a/docs/working-with-ai-agents-zh.md
+++ b/docs/working-with-ai-agents-zh.md
@@ -24,17 +24,17 @@
 
 这是我觉得最重要的一条。
 
-Agent 没有记忆，所以你得帮它建记忆。做法很简单：对话中产出的任何理解、决策、约定，写进文档，然后在 CLAUDE.md 里加索引。没被索引的文档等于不存在，未来 session 永远不会读到。
+Agent 没有记忆，所以你得帮它建记忆。做法很简单：对话中产出的任何理解、决策、约定，写进文档，然后在项目 instruction file 里加索引：Claude Code 用 `CLAUDE.md`，Codex / Antigravity 用 `AGENTS.md`。没被索引的文档等于不存在，未来 session 很可能不会读到。
 
-但 CLAUDE.md 本身不适合放细节。它会被加载到每个 session 开头，写太长就把 context 吃掉了。正确的分层：
+但 `CLAUDE.md` / `AGENTS.md` 本身不适合放细节。它会被加载到每个 session 开头，写太长就把 context 吃掉了。正确的分层：
 
 ```
-CLAUDE.md        ← 项目 overview + 文档索引（短，几十行）
-SKILL.md         ← 具体知识：架构、实验结论、工程教训（可以长）
-specific docs    ← 某个 topic 的深度文档
+CLAUDE.md / AGENTS.md            ← 项目 overview + 文档索引（短，几十行）
+.claude/.agents project-skill    ← 具体知识：架构、实验结论、工程教训（可以长）
+specific docs                    ← 某个 topic 的深度文档
 ```
 
-决策层和操作层分开。CLAUDE.md 告诉 agent "去哪里找信息"，SKILL.md 告诉它"信息是什么"。
+决策层和操作层分开。`CLAUDE.md` / `AGENTS.md` 告诉 agent "去哪里找信息"，project-skill 告诉它"信息是什么"。如果你同时用 Claude Code 和 Codex，`.claude/skills/project-skill/` 与 `.agents/skills/project-skill/` 必须镜像，并用 `scripts/check_agent_parity.sh` 防漂移。
 
 还有一个问题：`/compact` 等于遗忘。默认的 compact 会把之前的对话压缩掉，你刚教它的东西可能就没了。所以总结要频繁，最好用 hook 自动提醒。我用了几个：
 
@@ -160,7 +160,7 @@ Subagent（隔离 context）
         │ 写回
         ▼
 持久化文档
-  CLAUDE.md → SKILL.md → 各种 specific docs
+  CLAUDE.md / AGENTS.md → project-skill → 各种 specific docs
   跨 session 活着，对抗遗忘
 ```
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -3,63 +3,63 @@
     "UserPromptSubmit": [
       {
         "matcher": "",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" arxiv-detect", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" arxiv-detect", "async": false}]
       }
     ],
     "SessionStart": [
       {
         "matcher": "",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" session-start", "async": false}]
       }
     ],
     "PreCompact": [
       {
         "matcher": "",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-compact-remind", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" pre-compact-remind", "async": false}]
       },
       {
         "matcher": "",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-compact-archive", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" pre-compact-archive", "async": false}]
       }
     ],
     "PostToolUse": [
       {
         "matcher": "Bash",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-commit-changelog", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" post-commit-changelog", "async": false}]
       },
       {
         "matcher": "Bash",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-analyze-remind", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" post-analyze-remind", "async": false}]
       },
       {
         "matcher": "Bash",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-knowhow-remind", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" post-knowhow-remind", "async": false}]
       },
       {
         "matcher": "Bash",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-docs-remind", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" post-docs-remind", "async": false}]
       },
       {
         "matcher": "Bash",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-skill-stale", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" post-skill-stale", "async": false}]
       },
       {
         "matcher": "Write",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-new-experiment-monitor", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" post-new-experiment-monitor", "async": false}]
       },
       {
         "matcher": "Write",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-read-paper-survey", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" post-read-paper-survey", "async": false}]
       }
     ],
     "PreToolUse": [
       {
         "matcher": "Write",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" brainstorm-remind", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" brainstorm-remind", "async": false}]
       },
       {
         "matcher": "Bash",
-        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" worktree-suggest", "async": false}]
+        "hooks": [{"type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_ROOT:-.}}}/hooks/run-hook.cmd\" worktree-suggest", "async": false}]
       }
     ]
   }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -20,13 +20,23 @@ escape_for_json() {
 # Detect project state
 if [ ! -f ".pipeline-state.json" ]; then
     # Project not initialized — prompt to run /init-project
-    context="<labmate>\n\nLabMate is active but this project has not been initialized yet.\n\nRun /init-project to set up experiment directories, CLAUDE.md, and pipeline state.\n\nAvailable now: @domain-expert @project-advisor @exp-manager @slides-maker\n\n</labmate>"
+    context="<labmate>\n\nLabMate is active but this project has not been initialized yet.\n\nRun /init-project to set up experiment directories, AGENTS.md/CLAUDE.md, project-skill, and pipeline state.\n\nAvailable now: @domain-expert @project-advisor @exp-manager @slides-maker\n\n</labmate>"
 else
     # Project initialized — inject current state + workflow reminder
     current_exp=$(python3 -c "import json; print(json.load(open('.pipeline-state.json')).get('current_exp', 'null'))" 2>/dev/null || echo "null")
     stage=$(python3 -c "import json; print(json.load(open('.pipeline-state.json')).get('stage', 'dev'))" 2>/dev/null || echo "dev")
+    if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+        project_skill_path=".claude/skills/project-skill/SKILL.md"
+        fallback_project_skill_path=".agents/skills/project-skill/SKILL.md"
+    else
+        project_skill_path=".agents/skills/project-skill/SKILL.md"
+        fallback_project_skill_path=".claude/skills/project-skill/SKILL.md"
+    fi
+    if [ ! -f "$project_skill_path" ] && [ -f "$fallback_project_skill_path" ]; then
+        project_skill_path="$fallback_project_skill_path"
+    fi
 
-    context="<labmate>\n\nLabMate active. exp: ${current_exp} | stage: ${stage}\n\nWorkflow: /new-experiment -> /monitor -> /analyze-experiment -> /visualize -> /commit-changelog\n\nAgents: @domain-expert @project-advisor @exp-manager @slides-maker @viz-frontend\nSkills: /read-paper /survey-literature /new-experiment /analyze-experiment /visualize /monitor /commit-changelog /update-project-skill\n\nProject knowledge: .claude/skills/project-skill/SKILL.md\n\n</labmate>"
+    context="<labmate>\n\nLabMate active. exp: ${current_exp} | stage: ${stage}\n\nWorkflow: /new-experiment -> /monitor -> /analyze-experiment -> /visualize -> /commit-changelog\n\nAgents: @domain-expert @project-advisor @exp-manager @slides-maker @viz-frontend\nSkills: /read-paper /survey-literature /new-experiment /analyze-experiment /visualize /monitor /commit-changelog /update-project-skill\n\nProject knowledge: ${project_skill_path}\n\n</labmate>"
 fi
 
 # --- Periodic reminders (frequency-capped) ---

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labmate",
   "version": "0.7.1",
-  "description": "Research Harness for Claude Code",
+  "description": "Research harness for AI coding agents",
   "author": "freemty",
   "license": "MIT",
   "homepage": "https://github.com/freemty/labmate"

--- a/references/check_agent_parity.sh
+++ b/references/check_agent_parity.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_file() {
+  [ -f "$1" ] || fail "missing required file: $1"
+}
+
+require_dir() {
+  [ -d "$1" ] || fail "missing required directory: $1"
+}
+
+reject_contains() {
+  local pattern="$1"
+  shift
+  if command -v rg >/dev/null 2>&1; then
+    if rg -n "$pattern" "$@"; then
+      fail "forbidden pattern found: $pattern"
+    fi
+  elif grep -RInE "$pattern" "$@"; then
+    fail "forbidden pattern found: $pattern"
+  fi
+}
+
+if [ -f "CLAUDE.md" ] && [ -f "AGENTS.md" ]; then
+  require_file ".claude/skills/project-skill/SKILL.md"
+  require_file ".agents/skills/project-skill/SKILL.md"
+  cmp -s ".claude/skills/project-skill/SKILL.md" ".agents/skills/project-skill/SKILL.md" \
+    || fail "project-skill SKILL.md differs between .claude and .agents"
+
+  if [ -f ".claude/skills/project-skill/CHANGELOG.md" ] || [ -f ".agents/skills/project-skill/CHANGELOG.md" ]; then
+    require_file ".claude/skills/project-skill/CHANGELOG.md"
+    require_file ".agents/skills/project-skill/CHANGELOG.md"
+    cmp -s ".claude/skills/project-skill/CHANGELOG.md" ".agents/skills/project-skill/CHANGELOG.md" \
+      || fail "project-skill CHANGELOG.md differs between .claude and .agents"
+  fi
+
+  if [ -d ".claude/agent-memory" ] || [ -d ".agents/agent-memory" ]; then
+    require_dir ".claude/agent-memory"
+    require_dir ".agents/agent-memory"
+    diff -qr ".claude/agent-memory" ".agents/agent-memory" >/dev/null \
+      || fail "agent-memory differs between .claude and .agents"
+  fi
+fi
+
+search_paths=()
+for path in CLAUDE.md AGENTS.md .claude .agents docs; do
+  [ -e "$path" ] && search_paths+=("$path")
+done
+if [ "${#search_paths[@]}" -gt 0 ]; then
+  reject_contains "Codex Opus|AGENTS\\.md / AGENTS\\.md" "${search_paths[@]}"
+fi
+
+echo "agent parity check passed"

--- a/references/claude-md-template-general.md
+++ b/references/claude-md-template-general.md
@@ -14,11 +14,19 @@
 
 | What to do | Read first |
 |-----------|-----------|
-| Catch up on progress | .claude/skills/project-skill/SKILL.md |
+| Catch up on progress | {project-skill-path} |
 
 ## Project knowledge
 
-- **Skill hub:** .claude/skills/project-skill/SKILL.md
+- **Skill hub:** {project-skill-path}
+
+## Agent parity
+
+- Claude Code entrypoint: `CLAUDE.md`
+- Codex / Antigravity entrypoint: `AGENTS.md`
+- Claude project memory: `.claude/skills/project-skill/`
+- Codex / Antigravity project memory: `.agents/skills/project-skill/`
+- If both entrypoints exist, keep project-skill content mirrored and run `bash scripts/check_agent_parity.sh` after changing project memory or instruction files.
 
 ## Knowhow
 

--- a/references/claude-md-template-research.md
+++ b/references/claude-md-template-research.md
@@ -17,15 +17,23 @@
 
 | What to do | Read first |
 |-----------|-----------|
-| Catch up on progress | .claude/skills/project-skill/SKILL.md |
+| Catch up on progress | {project-skill-path} |
 | Check domain literature | docs/papers/landscape.md |
 | Run current experiment | exp/{current_exp}/README.md |
 
 ## Project knowledge
 
-- **Skill hub:** .claude/skills/project-skill/SKILL.md
+- **Skill hub:** {project-skill-path}
 - **Experiment log:** exp/summary.md
 - **Domain papers:** docs/papers/
+
+## Agent parity
+
+- Claude Code entrypoint: `CLAUDE.md`
+- Codex / Antigravity entrypoint: `AGENTS.md`
+- Claude project memory: `.claude/skills/project-skill/`
+- Codex / Antigravity project memory: `.agents/skills/project-skill/`
+- If both entrypoints exist, keep project-skill content mirrored and run `bash scripts/check_agent_parity.sh` after changing project memory or instruction files.
 
 ## Knowhow
 

--- a/skills/init-project/SKILL.md
+++ b/skills/init-project/SKILL.md
@@ -24,15 +24,26 @@ Initialize a project skeleton in the user's existing project. Supports two types
      > "检测到 git 工作区有未提交更改。继续将在此基础上写入文件。确认继续？(Y/n)"
    - 若用户回答 n，立即停止。
 
-2. 检查以下路径是否存在，记录结果（用于后续 skip 判断）：
+2. 检测 agent platform target，记录结果（用于后续 skip 判断）：
+   - Codex / Antigravity workspace target: `AGENTS.md` + `.agents/skills/project-skill/SKILL.md`
+   - Claude Code target: `CLAUDE.md` + `.claude/skills/project-skill/SKILL.md`
+   - 若当前运行环境是 Codex，优先 Codex target；若是 Claude Code，优先 Claude target。
+   - 若项目中两套 instruction file 已同时存在，则后续 Step 4 同步更新两者缺失 section。
+   - 若项目中两套 instruction file 已同时存在，则 project-skill 也必须保持 `.claude/` 与 `.agents/` 镜像一致。
+
+3. 检查以下路径是否存在，记录结果（用于后续 skip 判断）：
    - `CLAUDE.md`
+   - `AGENTS.md`
+   - `.claude/skills/project-skill/SKILL.md`
+   - `.agents/skills/project-skill/SKILL.md`
+   - `scripts/check_agent_parity.sh`
    - `exp/`
    - `docs/`
    - `.pipeline-state.json`
    - `.gitignore`
 
-3. 输出检测摘要（中文），例如：
-   > 检测结果：CLAUDE.md 不存在 | exp/ 已存在 | docs/ 不存在 | .pipeline-state.json 不存在 | .gitignore 已存在
+4. 输出检测摘要（中文），例如：
+   > 检测结果：target=codex | AGENTS.md 不存在 | .agents/skills/project-skill 不存在 | exp/ 已存在 | docs/ 不存在 | .pipeline-state.json 不存在 | .gitignore 已存在
 
 ---
 
@@ -113,7 +124,20 @@ Initialize a project skeleton in the user's existing project. Supports two types
 
 #### 3.4 project-skill 空模板
 
-若 `.claude/skills/project-skill/SKILL.md` 不存在，创建：
+根据 Step 1 检测到的 platform target 确定 project skill 路径：
+
+| Target | Project skill path | Changelog path |
+|--------|--------------------|----------------|
+| Codex / Antigravity workspace | `.agents/skills/project-skill/SKILL.md` | `.agents/skills/project-skill/CHANGELOG.md` |
+| Claude Code | `.claude/skills/project-skill/SKILL.md` | `.claude/skills/project-skill/CHANGELOG.md` |
+
+若项目中两套 instruction file 已同时存在，则两套 project-skill 路径都检查并补齐；若只存在当前 runtime 目标，则只创建当前目标。
+
+镜像规则：
+- 若一侧 project-skill 已存在、另一侧缺失，优先复制已存在侧的整个 `project-skill/` 目录到缺失侧，保留已积累知识。
+- 只有当目标侧和可复制的 counterpart 都不存在时，才创建下面的空模板。
+
+若目标路径的 `SKILL.md` 不存在，创建：
 
 ```markdown
 ---
@@ -136,7 +160,19 @@ user-invocable: false
 (none yet)
 ```
 
-将 `{project-name}` 和 `{description}` 替换为 Step 2 的值。确保 `.claude/skills/project-skill/` 目录存在。
+将 `{project-name}` 和 `{description}` 替换为 Step 2 的值。确保目标 `project-skill/` 目录存在。
+
+若目标 `project-skill/CHANGELOG.md` 不存在，创建：
+
+```markdown
+# project-skill CHANGELOG
+
+## {date} — v0
+
+Initial skeleton created by LabMate.
+```
+
+若两套 project-skill 都存在或本步骤创建了两套，确保两边 `SKILL.md` 和 `CHANGELOG.md` 内容一致。
 
 #### 3.5 CHANGELOG.md
 
@@ -216,7 +252,7 @@ Cross-experiment flight recorder. One row per experiment.
 
 ---
 
-### Step 4: 生成 CLAUDE.md
+### Step 4: 生成 agent instruction file
 
 **从插件读取模板：**
 
@@ -227,19 +263,38 @@ Cross-experiment flight recorder. One row per experiment.
    - `{project-name}` → Step 2 的项目名称
    - `{description}` → Step 2 的一句话描述
    - `{date}` → 今天日期，格式 `YYYY-MM-DD`
+   - `{project-skill-path}` → 当前 target 的 project skill 路径，例如 `.agents/skills/project-skill/SKILL.md`
 
 **写入规则：**
 
-- **若 `CLAUDE.md` 不存在**：直接写入替换后的完整模板。
+- 目标 instruction file：
+  - Codex / Antigravity workspace → `AGENTS.md`
+  - Claude Code → `CLAUDE.md`
+  - 若两者已同时存在，则对两者执行同样的缺失 section 追加逻辑。
 
-- **若 `CLAUDE.md` 已存在**：
-  1. 用 Read 读取现有 CLAUDE.md 内容
+- **若目标文件不存在**：直接写入替换后的完整模板。
+
+- **若目标文件已存在**：
+  1. 用 Read 读取现有文件内容
   2. 解析现有的 `## ` 二级标题列表（h2 sections）
   3. 解析模板的 `## ` 二级标题列表
   4. 找出模板中**存在但现有文件中缺失**的 section
-  5. 仅将缺失的 section（含其内容，直到下一个 `## ` 或文件末尾）**追加**到现有 CLAUDE.md 末尾
+  5. 仅将缺失的 section（含其内容，直到下一个 `## ` 或文件末尾）**追加**到现有文件末尾
   6. **绝对不删除、不修改**现有 section
-  7. 若所有 section 均已存在，输出"CLAUDE.md 已包含所有模板 section，跳过"
+  7. 若所有 section 均已存在，输出"{target file} 已包含所有模板 section，跳过"
+
+---
+
+### Step 4.5: Agent parity guard
+
+若项目中同时存在 `CLAUDE.md` 和 `AGENTS.md`，或同时存在 `.claude/skills/project-skill/` 与 `.agents/skills/project-skill/`：
+
+1. 确保 `scripts/` 目录存在。
+2. 若 `scripts/check_agent_parity.sh` 不存在，用 Read 读取 `<plugin_root>/references/check_agent_parity.sh` 并写入该路径。
+3. 用 Bash `chmod +x scripts/check_agent_parity.sh`。
+4. 运行 `bash scripts/check_agent_parity.sh`。若失败，报告具体失败原因，不要忽略。
+
+若只初始化单一平台目标，则跳过运行，但在摘要中提示：以后同时使用 Claude Code 和 Codex 时，应创建另一侧入口和 project-skill 镜像，并启用 parity guard。
 
 ---
 
@@ -301,7 +356,10 @@ Cross-experiment flight recorder. One row per experiment.
 2. 确认无误后提交：
    git add -A && git commit -m "chore: init project skeleton"
 
-3. （若 type=research）开始第一个实验：
+3. 若生成了 parity guard，验证：
+   bash scripts/check_agent_parity.sh
+
+4. （若 type=research）开始第一个实验：
    /labmate:new-experiment
    （若 type=general）刷新项目知识：
    /labmate:update-project-skill
@@ -323,6 +381,6 @@ Cross-experiment flight recorder. One row per experiment.
 
 - 已存在的文件：**只读，不覆盖**
 - `.gitignore` 规则：**逐行去重，不重复追加**
-- `CLAUDE.md` section：**仅追加缺失 section**
+- agent instruction file section：**仅追加缺失 section**
 - 目录：已存在则跳过 `mkdir`
 - `.pipeline-state.json`：已存在则完整跳过（不更新字段）

--- a/skills/todo/SKILL.md
+++ b/skills/todo/SKILL.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 
 # /todo
 
-Lightweight TODO tracking — one line per item, auto-indexed in CLAUDE.md.
+Lightweight TODO tracking — one line per item, auto-indexed in the project instruction file (`AGENTS.md` for Codex/Antigravity, `CLAUDE.md` for Claude Code).
 
 ## Usage
 
@@ -32,7 +32,8 @@ Parse user input:
 
 Check if `docs/TODO.md` exists in the project root. If not:
 1. Create it with header `# TODO`
-2. Add index entry to CLAUDE.md: `- \`docs/TODO.md\` — Project action items and task backlog`
+2. Add index entry to the active instruction file: `- \`docs/TODO.md\` — Project action items and task backlog`
+3. If both `AGENTS.md` and `CLAUDE.md` exist, add the same index entry to both.
 
 If file already exists, skip this step entirely.
 
@@ -86,5 +87,5 @@ Report: "Removed N completed items."
 |---------|---------|
 | Adding vague items like "fix that thing" | Ask for specifics |
 | Forgetting the date | Always append `— YYYY-MM-DD` |
-| Creating docs/TODO.md without indexing | Always check CLAUDE.md |
+| Creating docs/TODO.md without indexing | Always check `AGENTS.md` and `CLAUDE.md` when both exist |
 | Numbering completed items in `list` | Only number pending `- [ ]` items |

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -116,7 +116,7 @@ Existing file: append `## {Topic} ({date})` section, or update overlapping conte
 
 ### A5: Index Sync
 
-1. Read `CLAUDE.md`, search for `docs/knowhow/`
+1. Read the active instruction file (`AGENTS.md` for Codex/Antigravity, `CLAUDE.md` for Claude Code), search for `docs/knowhow/`. If both instruction files exist, check and update both.
 2. If NOT found, append:
 
 ```markdown
@@ -139,7 +139,7 @@ Or: 已更新 `docs/knowhow/{category}/{slug}.md` — {what was added}
 
 ## Branch B: Docs
 
-Create or update human-facing structured documents with automatic CLAUDE.md indexing.
+Create or update human-facing structured documents with automatic instruction-file indexing.
 
 ### B1: Determine Intent
 
@@ -179,7 +179,7 @@ For **creates**: scan codebase for relevant code to document.
 
 **Update:** Read existing → identify stale sections → edit (preserve user-written sections) → verify index.
 
-### B4: Auto-Index in CLAUDE.md
+### B4: Auto-Index in Agent Instructions
 
 | Path pattern | Index action |
 |--------------|-------------|
@@ -188,7 +188,7 @@ For **creates**: scan codebase for relevant code to document.
 | `README.md`, `CHANGELOG.md` | Skip (already discoverable) |
 | Custom paths | Add to most relevant section |
 
-Check before adding: `grep -q "<path>" CLAUDE.md` — only add if not present.
+Check before adding: `grep -q "<path>" AGENTS.md CLAUDE.md 2>/dev/null` — only add if not present. Add to the active instruction file; if both files exist, update both so Claude Code and Codex see the same documentation index.
 
 ### B5: Report
 
@@ -207,6 +207,6 @@ Check before adding: `grep -q "<path>" CLAUDE.md` — only add if not present.
 | Writing agent-facing knowledge to docs/ | That's knowhow → Branch A |
 | Writing human-facing docs to docs/knowhow/ | That's docs → Branch B |
 | Overwriting user-written content | Only update generated/stale sections |
-| Forgetting CLAUDE.md index | Always check + add/update |
+| Forgetting instruction-file index | Always check + add/update `AGENTS.md` or `CLAUDE.md` |
 | Creating new knowhow subdirectories | Only 4 fixed categories allowed |
 | Calling subagent | All info is in conversation context, execute directly |

--- a/skills/update-project-skill/SKILL.md
+++ b/skills/update-project-skill/SKILL.md
@@ -9,11 +9,24 @@ disable-model-invocation: true
 
 # Update Project Skill
 
-Refreshes `.claude/skills/project-skill/SKILL.md` by scanning the entire project.
+Refreshes the project-local `project-skill/SKILL.md` by scanning the entire project.
+
+## Platform Paths
+
+Choose the project skill path before running:
+
+| Target | Project skill path | Instruction file |
+|--------|--------------------|------------------|
+| Codex / Antigravity workspace | `.agents/skills/project-skill/SKILL.md` | `AGENTS.md` |
+| Claude Code | `.claude/skills/project-skill/SKILL.md` | `CLAUDE.md` |
+
+Prefer the current runtime target. If both project skill paths already exist, or both `CLAUDE.md` and `AGENTS.md` exist, update the current runtime path first and mirror the final approved content to the other path before finishing.
+
+If `scripts/check_agent_parity.sh` exists, run it after mirroring. A failed parity check means the command is not complete.
 
 ## Detect Mode
 
-Check if `.claude/skills/project-skill/SKILL.md` is empty or only contains skeleton placeholder content.
+Check if the selected project skill file is empty or only contains skeleton placeholder content.
 
 - **Bootstrap mode** (first run / empty SKILL.md): deep scan, generate from scratch
 - **Update mode** (existing SKILL.md): incremental update, preserve existing content
@@ -28,7 +41,7 @@ Use the Agent tool to spawn an Opus subagent. Provide different prompts dependin
 
 > You are initializing the project knowledge base for the first time. Do a DEEP scan:
 >
-> 1. **Project identity**: Read CLAUDE.md, README.md, pyproject.toml/package.json → extract project name, description, purpose, motivation
+> 1. **Project identity**: Read AGENTS.md and/or CLAUDE.md, README.md, pyproject.toml/package.json → extract project name, description, purpose, motivation
 > 2. **Architecture**: Use Glob to map directory tree. Read key entry points. Identify: what does this project do? What are the main modules?
 > 3. **Design decisions**: Read docs/specs/, docs/archive/ → extract key architectural decisions and rejected alternatives
 > 4. **Experiment history**: Scan exp/*/README.md → build experiment table (ID, description, status, key finding)
@@ -43,7 +56,7 @@ Use the Agent tool to spawn an Opus subagent. Provide different prompts dependin
 
 > You are refreshing the project knowledge base. Do an INCREMENTAL scan:
 >
-> 1. Read current `.claude/skills/project-skill/SKILL.md` — preserve structure and user-added custom sections
+> 1. Read current selected project skill file — preserve structure and user-added custom sections
 > 2. Read `exp/` for new or updated experiments since last update
 > 3. Read `prompts/` for version changes
 > 4. Run `git log --oneline -20` for recent changes
@@ -78,10 +91,20 @@ Write the updated SKILL.md.
 
 ### Step 4: Append CHANGELOG
 
-Append entry to `.claude/skills/project-skill/CHANGELOG.md` with date and summary.
+Append entry to the selected `project-skill/CHANGELOG.md` with date and summary. If the counterpart platform path exists, mirror the same final `SKILL.md` and `CHANGELOG.md` there too. If both `CLAUDE.md` and `AGENTS.md` exist but the counterpart `project-skill/` directory is missing, create it and mirror the final files there.
 In bootstrap mode: "Initial bootstrap — auto-generated from existing codebase"
 
-### Step 5: Update pipeline state
+### Step 5: Check parity
+
+If `scripts/check_agent_parity.sh` exists, run:
+
+```bash
+bash scripts/check_agent_parity.sh
+```
+
+If it fails, fix the mirror drift before reporting completion.
+
+### Step 6: Update pipeline state
 
 ```python
 import json, time
@@ -90,6 +113,6 @@ state['skill_updated_at'] = int(time.time())
 json.dump(state, open('.pipeline-state.json', 'w'), indent=2)
 ```
 
-### Step 6: Prompt next action
+### Step 7: Prompt next action
 
 "Also run /commit-changelog? (Y/n)"


### PR DESCRIPTION
## Summary

- Add Codex/Antigravity project-memory parity for LabMate via AGENTS.md and .agents/skills/project-skill support.
- Add a reusable parity guard script and platform-aware hook/runtime paths.
- Update init/update skills, templates, docs, and active-agent boundaries so Claude Code and Codex project memory stay mirrored when both are present.

## Validation

- `git diff --check`
- `bash -n references/check_agent_parity.sh && bash -n hooks/session-start`
- `python3 -m json.tool .codex-plugin/plugin.json`
- `python3 -m json.tool hooks/hooks.json`
- `python3 scripts/validate_skills.py`
- temporary clean `HOME` install: `./install.sh --target codex`
